### PR TITLE
Fixes to make build possible with modern kernel.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ ifneq ($(version_compatibility),)
 	EXTRA_CFLAGS += -DVERSION_COMPATIBILITY
 endif
 
-obj-m := u3v.o
+obj-m += u3v.o
 u3v-objs := u3v_core.o u3v_control.o u3v_event.o u3v_stream.o
 
 else
@@ -51,23 +51,24 @@ PWD := $(shell pwd)
 
 MOD_DIR := kernel/natinst/u3v
 MOD_PATH := /lib/modules/$(shell uname -r)/$(MOD_DIR)
+KERNELHEADERS := /usr/src/linux-headers-$(shell uname -r)
 
 all:
-	@$(MAKE) --no-print-directory -C $(KERNELHEADERS) M=$(PWD) modules
+	$(MAKE) -C $(KERNELHEADERS) M=$(PWD) modules
 
 debug: all
 	EXTRA_CFLAGS += -DDEBUG -g
 
 install: all
-	@$(MAKE) --no-print-directory -C $(KERNELHEADERS) M=$(PWD) INSTALL_MOD_DIR=$(MOD_DIR) modules_install
+	$(MAKE) -C $(KERNELHEADERS) M=$(PWD) INSTALL_MOD_DIR=$(MOD_DIR) modules_install
 
 uninstall:
-	@$(RM) -rf $(MOD_PATH)
-	@/sbin/depmod -a
+	$(RM) -rf $(MOD_PATH)
+	/sbin/depmod -a
 
 clean:
-	@$(MAKE) --no-print-directory -s -C $(KERNELHEADERS) M=$(PWD) clean
-	@$(RM) -rf Module.*
+	$(MAKE) -s -C $(KERNELHEADERS) M=$(PWD) clean
+	$(RM) -rf Module.*
 
 .PHONY: all install uninstall clean
 

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,12 @@ PWD := $(shell pwd)
 
 MOD_DIR := kernel/natinst/u3v
 MOD_PATH := /lib/modules/$(shell uname -r)/$(MOD_DIR)
-KERNELHEADERS := /usr/src/linux-headers-$(shell uname -r)
+
+$(warning Be sure you have set correct path in KERNELHEADERS)
+ifeq ($(KERNELHEADERS),)
+	KERNELHEADERS := /usr/src/linux-headers-$(shell uname -r)
+endif
+$(warning Path is set to: $(KERNELHEADERS))
 
 all:
 	$(MAKE) -C $(KERNELHEADERS) M=$(PWD) modules

--- a/u3v_core.c
+++ b/u3v_core.c
@@ -42,6 +42,7 @@
 #include <linux/lcm.h>
 #include <linux/module.h>
 #include <linux/scatterlist.h>
+#include <linux/stat.h>
 #include <linux/slab.h>
 #include <linux/sysfs.h>
 #include <linux/types.h>
@@ -135,7 +136,7 @@ static ssize_t name##_store(struct device *dev,				\
 									\
 	return count;							\
 }									\
-static DEVICE_ATTR(name, S_IWUGO | S_IRUGO, name##_show, name##_store);
+static DEVICE_ATTR(name, S_IWUSR | S_IWGRP | S_IRUGO, name##_show, name##_store);
 
 #define u3v_attribute_str(name)						\
 static ssize_t name##_show(struct device *dev,				\

--- a/u3v_stream.c
+++ b/u3v_stream.c
@@ -1348,14 +1348,11 @@ static struct page **lock_user_pages(struct u3v_stream *stream,
 	down_read(&current->mm->mmap_sem);
 	/* will store a page locked array of physical pages in pages var */
 	ret = get_user_pages(
-		current,
-		current->mm,
-		uaddr,
-		num_pages,
-		WRITE,
-		0, /* Don't force */
-		pages,
-		NULL);
+            uaddr,
+            num_pages,
+            WRITE,
+            pages,
+            NULL);
 	up_read(&current->mm->mmap_sem);
 
 	if (ret < num_pages) {


### PR DESCRIPTION
fixes #3 

Additionally, it contains patch for newer implementation of get_user_pages.
Also included warning regarding `KERNELHEADERS`, default set that variable to `/usr/src/linux-headers-$(shell uname -r)`) and removed "silent" calls in Makefile.