### PR TITLE
 Use <linux/unaligned.h> instead of <asm/unaligned.h> for kernel >=6.12

### DIFF
--- a/u3v_control.c
+++ b/u3v_control.c
@@ -48,6 +48,8 @@
 #else
 	#include <generated/uapi/linux/version.h>
 #endif
+// In the kernel version >= 6.12.0, <asm/unaligned.h> is removed and replaced with <linux/unaligned.h>.
+// See these patches: https://lore.kernel.org/linux-parisc/20241002221749.GI4017910@ZenIV/T/
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
 	#include <linux/unaligned.h>
 #else

--- a/u3v_control.c
+++ b/u3v_control.c
@@ -43,7 +43,11 @@
 #include <linux/usb.h>
 #include <linux/types.h>
 #include <linux/uaccess.h>
-#include <linux/version.h>
+#ifdef VERSION_COMPATIBILITY
+	#include <linux/version.h>
+#else
+	#include <generated/uapi/linux/version.h>
+#endif
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
 	#include <linux/unaligned.h>
 #else

--- a/u3v_control.c
+++ b/u3v_control.c
@@ -49,7 +49,7 @@
 	#include <generated/uapi/linux/version.h>
 #endif
 // In the kernel version >= 6.12.0, <asm/unaligned.h> is removed and replaced with <linux/unaligned.h>.
-// See these patches: https://lore.kernel.org/linux-parisc/20241002221749.GI4017910@ZenIV/T/
+// See this commit: https://github.com/torvalds/linux/commit/5f60d5f6bbc12e782fac78110b0ee62698f3b576
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
 	#include <linux/unaligned.h>
 #else

--- a/u3v_control.c
+++ b/u3v_control.c
@@ -44,7 +44,11 @@
 #include <linux/types.h>
 #include <linux/uaccess.h>
 #include <linux/version.h>
-#include <asm/unaligned.h>
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
+	#include <linux/unaligned.h>
+#else
+	#include <asm/unaligned.h>
+#endif
 
 /*
  * u3v_create_control - Initializes the control interface.

--- a/u3v_core.c
+++ b/u3v_core.c
@@ -53,7 +53,7 @@
 	#include <generated/uapi/linux/version.h>
 #endif
 // In the kernel version >= 6.12.0, <asm/unaligned.h> is removed and replaced with <linux/unaligned.h>.
-// See these patches: https://lore.kernel.org/linux-parisc/20241002221749.GI4017910@ZenIV/T/
+// See this commit: https://github.com/torvalds/linux/commit/5f60d5f6bbc12e782fac78110b0ee62698f3b576
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
 	#include <linux/unaligned.h>
 #else

--- a/u3v_core.c
+++ b/u3v_core.c
@@ -47,7 +47,11 @@
 #include <linux/types.h>
 #include <linux/uaccess.h>
 #include <linux/usb.h>
-#include <asm/unaligned.h>
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
+	#include <linux/unaligned.h>
+#else
+	#include <asm/unaligned.h>
+#endif
 #ifdef VERSION_COMPATIBILITY
 	#include <linux/version.h>
 #else

--- a/u3v_core.c
+++ b/u3v_core.c
@@ -52,6 +52,8 @@
 #else
 	#include <generated/uapi/linux/version.h>
 #endif
+// In the kernel version >= 6.12.0, <asm/unaligned.h> is removed and replaced with <linux/unaligned.h>.
+// See these patches: https://lore.kernel.org/linux-parisc/20241002221749.GI4017910@ZenIV/T/
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
 	#include <linux/unaligned.h>
 #else

--- a/u3v_core.c
+++ b/u3v_core.c
@@ -47,15 +47,15 @@
 #include <linux/types.h>
 #include <linux/uaccess.h>
 #include <linux/usb.h>
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
-	#include <linux/unaligned.h>
-#else
-	#include <asm/unaligned.h>
-#endif
 #ifdef VERSION_COMPATIBILITY
 	#include <linux/version.h>
 #else
 	#include <generated/uapi/linux/version.h>
+#endif
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
+	#include <linux/unaligned.h>
+#else
+	#include <asm/unaligned.h>
 #endif
 
 

--- a/u3v_stream.c
+++ b/u3v_stream.c
@@ -51,7 +51,11 @@
 #include <linux/uaccess.h>
 #include <linux/usb.h>
 #include <linux/vmalloc.h>
-#include <asm/unaligned.h>
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
+	#include <linux/unaligned.h>
+#else
+	#include <asm/unaligned.h>
+#endif
 #ifdef VERSION_COMPATIBILITY
 	#include <linux/version.h>
 #else

--- a/u3v_stream.c
+++ b/u3v_stream.c
@@ -56,6 +56,8 @@
 #else
 	#include <generated/uapi/linux/version.h>
 #endif
+// In the kernel version >= 6.12.0, <asm/unaligned.h> is removed and replaced with <linux/unaligned.h>.
+// See these patches: https://lore.kernel.org/linux-parisc/20241002221749.GI4017910@ZenIV/T/
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
 	#include <linux/unaligned.h>
 #else

--- a/u3v_stream.c
+++ b/u3v_stream.c
@@ -51,17 +51,16 @@
 #include <linux/uaccess.h>
 #include <linux/usb.h>
 #include <linux/vmalloc.h>
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
-	#include <linux/unaligned.h>
-#else
-	#include <asm/unaligned.h>
-#endif
 #ifdef VERSION_COMPATIBILITY
 	#include <linux/version.h>
 #else
 	#include <generated/uapi/linux/version.h>
 #endif
-
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
+	#include <linux/unaligned.h>
+#else
+	#include <asm/unaligned.h>
+#endif
 
 /* Internal stream structs and enums */
 

--- a/u3v_stream.c
+++ b/u3v_stream.c
@@ -57,7 +57,7 @@
 	#include <generated/uapi/linux/version.h>
 #endif
 // In the kernel version >= 6.12.0, <asm/unaligned.h> is removed and replaced with <linux/unaligned.h>.
-// See these patches: https://lore.kernel.org/linux-parisc/20241002221749.GI4017910@ZenIV/T/
+// See this commit: https://github.com/torvalds/linux/commit/5f60d5f6bbc12e782fac78110b0ee62698f3b576
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
 	#include <linux/unaligned.h>
 #else


### PR DESCRIPTION
In this commit https://github.com/torvalds/linux/commit/5f60d5f6bbc12e782fac78110b0ee62698f3b576

For Linux kernel 6.12, <asm/unaligned.h> is removed and <linux/unaligned.h> is intended instead. Check the version and use the corresponding header.

See internal azdo PR !951438